### PR TITLE
fix: Update dependencies for SecretManager and KubernetesGenerator

### DIFF
--- a/tests/Devantler.SOPSCLI.Tests/Devantler.SOPSCLI.Tests.csproj
+++ b/tests/Devantler.SOPSCLI.Tests/Devantler.SOPSCLI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.1.*" />
-    <PackageReference Include="Devantler.KubernetesGenerator.Native" Version="1.0.*" />
+    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.3.4" />
+    <PackageReference Include="Devantler.KubernetesGenerator.Native" Version="1.5.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Devantler.SecretManager.SOPS.LocalAge to version 1.3.4 and Devantler.KubernetesGenerator.Native to version 1.5.3 to ensure compatibility and access to the latest features.