### PR TITLE
fix: Replace Devantler.CLIRunner with CLIWrap for command execution

### DIFF
--- a/src/Devantler.SOPSCLI/Devantler.SOPSCLI.csproj
+++ b/src/Devantler.SOPSCLI/Devantler.SOPSCLI.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.38" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -44,7 +44,6 @@ public static class SOPS
   /// <param name="arguments"></param>
   /// <param name="validation"></param>
   /// <param name="silent"></param>
-  /// <param name="includeStdIn"></param>
   /// <param name="includeStdErr"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>

--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.SOPSCLI;
 

--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using CliWrap;
+using CliWrap.Buffered;
 using Devantler.CLIRunner;
 
 namespace Devantler.SOPSCLI;
@@ -54,11 +55,15 @@ public static class SOPS
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    return await CLI.RunAsync(
-      Command.WithArguments(arguments),
-      validation: validation,
-      silent: silent,
-      includeStdErr: includeStdErr,
-      cancellationToken: cancellationToken).ConfigureAwait(false);
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardInput();
+    using var stdErr = Console.OpenStandardError();
+    var command = Command.WithArguments(arguments)
+      .WithValidation(validation)
+      .WithStandardInputPipe(PipeSource.FromStream(stdIn))
+      .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
+      .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
+    var result = await command.ExecuteBufferedAsync(cancellationToken);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }

--- a/tests/Devantler.SOPSCLI.Tests/SOPSTests/RunAsyncTests.cs
+++ b/tests/Devantler.SOPSCLI.Tests/SOPSTests/RunAsyncTests.cs
@@ -3,7 +3,7 @@ using CliWrap;
 namespace Devantler.SOPSCLI.Tests.SOPSTests;
 
 /// <summary>
-/// Tests for the <see cref="SOPS.RunAsync(string[], CommandResultValidation, bool, bool, CancellationToken)" /> method.
+/// Tests for the <see cref="SOPS.RunAsync(string[], CommandResultValidation, bool, bool, bool, CancellationToken)" /> method.
 /// </summary>
 public class RunAsyncTests
 {

--- a/tests/Devantler.SOPSCLI.Tests/SOPSTests/RunAsyncTests.cs
+++ b/tests/Devantler.SOPSCLI.Tests/SOPSTests/RunAsyncTests.cs
@@ -3,7 +3,7 @@ using CliWrap;
 namespace Devantler.SOPSCLI.Tests.SOPSTests;
 
 /// <summary>
-/// Tests for the <see cref="SOPS.RunAsync(string[], CommandResultValidation, bool, bool, bool, CancellationToken)" /> method.
+/// Tests for the <see cref="SOPS.RunAsync(string[], CommandResultValidation, bool, bool, CancellationToken)" /> method.
 /// </summary>
 public class RunAsyncTests
 {


### PR DESCRIPTION
Switch to CLIWrap for improved command execution logic and update related implementation details.