### PR TITLE
feat(SOPS): enhance command execution to support 'edit' argument

### DIFF
--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 using CliWrap;
 using CliWrap.Buffered;
 

--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -55,6 +55,7 @@ public static class SOPS
     bool silent = false,
     CancellationToken cancellationToken = default)
   {
+    ArgumentNullException.ThrowIfNull(arguments, nameof(arguments));
     if (arguments[0] == "edit")
     {
       var process = new ProcessStartInfo

--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using CliWrap;


### PR DESCRIPTION
Introduce support for the 'edit' argument in command execution, allowing for a different process handling when this argument is used. This change improves the flexibility of command execution within the SOPS functionality.