### PR TITLE
fix: add support for Windows arm64 binary in SOPS command retrieval

### DIFF
--- a/src/Devantler.SOPSCLI/SOPS.cs
+++ b/src/Devantler.SOPSCLI/SOPS.cs
@@ -25,6 +25,7 @@ public static class SOPS
       (PlatformID.Unix, Architecture.X64, "linux-x64") => "sops-linux-x64",
       (PlatformID.Unix, Architecture.Arm64, "linux-arm64") => "sops-linux-arm64",
       (PlatformID.Win32NT, Architecture.X64, "win-x64") => "sops-win-x64.exe",
+      (PlatformID.Win32NT, Architecture.Arm64, "win-arm64") => "sops-win-arm64.exe",
       _ => throw new PlatformNotSupportedException($"Unsupported platform: {Environment.OSVersion.Platform} {RuntimeInformation.ProcessArchitecture}"),
     };
     string binaryPath = Path.Combine(AppContext.BaseDirectory, binary);

--- a/tests/Devantler.SOPSCLI.Tests/SOPSTests/GetCommandTests.cs
+++ b/tests/Devantler.SOPSCLI.Tests/SOPSTests/GetCommandTests.cs
@@ -17,7 +17,7 @@ public class GetCommandTests
   [InlineData(PlatformID.Unix, Architecture.Arm64, "linux-arm64", "sops-linux-arm64")]
   [InlineData(PlatformID.Win32NT, Architecture.X64, "win-x64", "sops-win-x64.exe")]
   [InlineData(PlatformID.Win32NT, Architecture.Arm64, "win-arm64", "sops-win-arm64.exe")]
-  public void GetCommand_ShouldReturnOSXx64Binary(PlatformID platformID, Architecture architecture, string runtimeIdentifier, string expectedBinary)
+  public void GetCommand_ShouldReturnBinary(PlatformID platformID, Architecture architecture, string runtimeIdentifier, string expectedBinary)
   {
     // Act
     string actualBinary = Path.GetFileName(SOPS.GetCommand(platformID, architecture, runtimeIdentifier).TargetFilePath);


### PR DESCRIPTION
Introduce support for the Windows arm64 architecture in the SOPS command retrieval logic and update tests accordingly.